### PR TITLE
Add a silent method to get volume for sliding panel

### DIFF
--- a/ovos_PHAL_plugin_alsa/__init__.py
+++ b/ovos_PHAL_plugin_alsa/__init__.py
@@ -21,6 +21,11 @@ class AlsaVolumeControlPlugin(PHALPlugin):
         self.bus.on("mycroft.volume.unmute", self.handle_unmute_request)
         self.bus.on("mycroft.volume.mute.toggle", self.handle_mute_toggle_request)
 
+        # A silent method to get the volume without invoking the shell osd
+        # Needed as gui will always refresh and request it
+        # When sliding panel opens to refresh volume value data
+        self.bus.on("mycroft.volume.get.silent", self.handle_get_silent)
+
         if self.settings.get("first_boot", True):
             self.set_volume(50)
             self.settings["first_boot"] = False
@@ -76,6 +81,10 @@ class AlsaVolumeControlPlugin(PHALPlugin):
             {"percent": 0 if muted else (self.alsa.get_volume_percent() / 100)}))
 
     def handle_volume_request(self, message):
+        percent = self.get_volume() / 100
+        self.bus.emit(message.response({"percent": percent}))
+
+    def handle_get_silent(self, message):
         percent = self.get_volume() / 100
         self.bus.emit(message.response({"percent": percent}))
 


### PR DESCRIPTION
- Allow the sliding panel to get the volume without invoking and waking up the osd everytime the sliding panel opens to get the latest volume value