### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -7,4 +7,6 @@ on:
       - master
 jobs:
   license_tests:
-    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
+    uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
+    with:
+      system_deps: "libasound2-dev"

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish_stable:
-    uses: TigreGotico/gh-automations/.github/workflows/publish-stable.yml@master
+    uses: TigreGotico/gh-automations/.github/workflows/publish-stable.yml@dev
     secrets: inherit
     with:
       branch: 'master'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish_alpha:
-    uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
+    uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@dev
     secrets: inherit
     with:
       branch: 'dev'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,13 +5,13 @@ on:
 
 jobs:
   py_build_tests:
-    uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
+    uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
-      python_version: "3.8"
+      system_deps: "libasound2-dev"
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.9, "3.10", "3.11" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-plugin-manager>=0.0.1,<3.0.0
-ovos-bus-client>=0.0.4,<2.0.0
+ovos-bus-client>=0.0.4,<3.0.0
 json_database~=0.7
 pyalsaaudio~=0.9


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.