### PR TITLE
fix: allow json-database 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["ovos", "phal", "plugin"]
 dependencies = [
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "ovos-bus-client>=0.0.4,<3.0.0",
-    "json_database~=0.7",
+    "json_database>=0.7,<2.0.0",
     "pyalsaaudio~=0.9"
 ]
 


### PR DESCRIPTION
`json_database~=0.7` resolves to `>=0.7,<1.0`, excluding json_database 1.x (now published as `1.0.2a1`). Widen to `>=0.7,<2.0.0` so this plugin doesn't hold json_database below 1.x in the ovos-releases alpha set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)